### PR TITLE
Add support for pbtech style

### DIFF
--- a/styles/pbtech/template/event/overall_header_head_append.html
+++ b/styles/pbtech/template/event/overall_header_head_append.html
@@ -1,0 +1,1 @@
+<!-- INCLUDECSS @dmzx_fixedfooternavbar/fixedfooternavbar.css -->

--- a/styles/pbtech/theme/fixedfooternavbar.css
+++ b/styles/pbtech/theme/fixedfooternavbar.css
@@ -1,0 +1,22 @@
+/*
+*
+* @package Fixed footer navbar
+* @author dmzx (www.dmzx-web.net)
+* @copyright (c) 2014 by dmzx (www.dmzx-web.net)
+* @license http://opensource.org/licenses/gpl-license.php GNU Public License
+*
+*/
+
+#page-footer .navbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 99%;
+    max-width: 100%;
+    background: url("./images/bg.jpg") no-repeat scroll 50% 70% #000;
+    box-shadow: 0 0 2px 2px #000000;
+}
+
+#page-footer {
+    padding-bottom: 30px;
+}


### PR DESCRIPTION
Hi,
in PbTech style your version of navbar was transparent and not over whole bottom.
So I rewrote it for pbtech.
Old looked like this: http://ctrlv.cz/IUSd
This commit changes it into this: http://ctrlv.cz/1BxH
Biosek
